### PR TITLE
Enabling landing page for all scenarios

### DIFF
--- a/src/edgeDebugAdapter.ts
+++ b/src/edgeDebugAdapter.ts
@@ -86,18 +86,16 @@ export class EdgeDebugAdapter extends CoreDebugAdapter {
                 launchUrl = args.url;
             }
             if (launchUrl) {
-                if (args.breakOnLoadStrategy !== 'off') {
-                    // We store the launch file/url provided by the user and temporarily launch and attach to a custom landing page using file url.
-                    // Once we receive configurationDone() event, we redirect the page to the user file/url
-                    // This is done to facilitate hitting breakpoints on load
-                    this._userRequestedUrl = launchUrl;
-                    // The compiled file lives in root/out/src while the landingPage will live in root/
-                    /* So when this script is getting executed from the %programdata% directory under EdgeAdapter/out/src, we need to find the
-                    landingPage under EdgeAdapter/ hence we need to go 2 directories up */
-                    let landingPagePath = path.dirname(path.dirname(__dirname));
-                    launchUrl = encodeURI("file:///" + landingPagePath + "/landingPage.html");
-                    this._breakOnLoadActive = true;
-                }
+                // We store the launch file/url provided by the user and temporarily launch and attach to a custom landing page using file url.
+                // Once we receive configurationDone() event, we redirect the page to the user file/url
+                // This is done to facilitate hitting breakpoints on load and to solve timeout issues
+                this._userRequestedUrl = launchUrl;
+                // The compiled file lives in root/out/src while the landingPage will live in root/
+                /* So when this script is getting executed from the %programdata% directory under EdgeAdapter/out/src, we need to find the
+                landingPage under EdgeAdapter/ hence we need to go 2 directories up */
+                let landingPagePath = path.dirname(path.dirname(__dirname));
+                launchUrl = encodeURI("file:///" + landingPagePath + "/landingPage.html");
+                this._breakOnLoadActive = true;
 
                 edgeArgs.push(launchUrl);
             }


### PR DESCRIPTION
Enabling the landing page even when break on load is off so that we don't run into timeout issues.