### PR TITLE
Adding csproj and solution file for microbuild signing

### DIFF
--- a/msbuild/EdgeDebugAdapter.csproj
+++ b/msbuild/EdgeDebugAdapter.csproj
@@ -1,0 +1,59 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="images\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="node_modules\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="out\src\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include=".gitignore">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include=".travis.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="appveyor.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="landingPage.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="LICENSE">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="package.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="package.nls.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="package-lock.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="README.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <FilesToSign Include="$(OutDir)\**\*.js">
+      <Authenticode>Microsoft</Authenticode>
+      <StrongName>StrongName</StrongName>
+    </FilesToSign>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MicroBuild.Core">
+      <Version>0.2.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/msbuild/EdgeDebugAdapter.sln
+++ b/msbuild/EdgeDebugAdapter.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27422.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdgeDebugAdapter", "EdgeDebugAdapter.csproj", "{FF72AE19-1081-4A1D-A2EA-EA50A3530289}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FF72AE19-1081-4A1D-A2EA-EA50A3530289}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF72AE19-1081-4A1D-A2EA-EA50A3530289}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF72AE19-1081-4A1D-A2EA-EA50A3530289}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF72AE19-1081-4A1D-A2EA-EA50A3530289}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A0031A13-F520-495A-A28F-38294166BF6F}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
The csproj and sln files will not be connected to anything else in the repo, and will be effectively inert and ignorable to all other users.
But we are creating a signing microbuild definition, which when run will msbuild the csproj file, and that build create a zip file containing signed versions of the JS files in the extension.  This signed zip will be used to produce the nuget file that will eventually be automatically inserted into the VS willow tree and setup.