### PR TITLE
More work on the signing microbuild integration

### DIFF
--- a/msbuild/EdgeDebugAdapter.csproj
+++ b/msbuild/EdgeDebugAdapter.csproj
@@ -43,7 +43,7 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="GetFilesToSign" BeforeTargets="AfterBuild">
+  <Target Name="GetFilesToSign" DependsOnTargets="Build" BeforeTargets="AfterBuild">
     <ItemGroup>
       <FilesToSign Include="$(OutDir)\**\*.js">
         <Authenticode>Microsoft</Authenticode>


### PR DESCRIPTION
Now the builds are passing, but it's still not signing our files.  Hopefully these timing changes will fix the problem.