### PR TITLE
Now we can specify the package name when packaging

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -140,7 +140,11 @@ gulp.task('vsce-publish', function () {
     return vsce.publish();
 });
 gulp.task('vsce-package', function () {
-    return vsce.createVSIX();
+    const usePackagePathOptionIndex = process.argv.findIndex(arg => arg === "--packagePath");
+    const options = (usePackagePathOptionIndex >= 0 && usePackagePathOptionIndex < process.argv.length)
+        ? { packagePath: process.argv[usePackagePathOptionIndex + 1] }
+        : {};
+    return vsce.createVSIX(options);
 });
 
 gulp.task('publish', function (callback) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -141,9 +141,8 @@ gulp.task('vsce-publish', function () {
 });
 gulp.task('vsce-package', function () {
     const usePackagePathOptionIndex = process.argv.findIndex(arg => arg === "--packagePath");
-    const options = (usePackagePathOptionIndex >= 0 && usePackagePathOptionIndex < process.argv.length)
-        ? { packagePath: process.argv[usePackagePathOptionIndex + 1] }
-        : {};
+    const packagePath = process.argv[usePackagePathOptionIndex + 1];
+    const options = packagePath !== undefined ? { packagePath: packagePath } : {};
     return vsce.createVSIX(options);
 });
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "intTest": "mocha --timeout 20000 -s 3500 -u tdd --colors --reporter node_modules/vscode-chrome-debug-core-testsupport/out/loggingReporter.js ./out/test/int/*.test.js",
     "lint": "gulp tslint",
     "vscode:prepublish": "gulp verify-no-linked-modules",
-    "postinstall": "node ./node_modules/vscode/bin/install"
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "package": "gulp package"
   },
   "contributes": {
     "breakpoints": [


### PR DESCRIPTION
We'll use this command in our build system. Generating a .vsix with the same name always makes it easier to configure the build system. We'll use "npm run package -- --packagePath edge-debug2.vsix"