### PR TITLE
Fix unit tests, update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6107,9 +6107,9 @@
       }
     },
     "vscode-chrome-debug-core": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-5.0.2.tgz",
-      "integrity": "sha512-9D93CMIe+iIZaiUAIZZRGnq9fZsDjqKBayWqnHGkEWv9x21qeHK9mPEbXHQj4GHXbbSAtifnreWuKhfdGgjWbA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-5.0.3.tgz",
+      "integrity": "sha512-EYx9Nm5gqCYhkKtewEjS2EBFQeZujyyfcovTWtocDnNsgCVF5DgRUxLKoMcRzK9KAtLLU00BG/rBLpqWuM7IZA==",
       "requires": {
         "@types/source-map": "0.1.29",
         "devtools-protocol": "0.0.547074",

--- a/test/edgeDebugAdapter.test.ts
+++ b/test/edgeDebugAdapter.test.ts
@@ -39,15 +39,12 @@ suite('EdgeDebugAdapter', () => {
         mockery.enable({ useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false });
 
         // Create a ChromeConnection mock with .on and .attach. Tests can fire events via mockEventEmitter
-        mockEdgeConnection = Mock.ofType(chromeConnection.ChromeConnection, MockBehavior.Strict);
+        mockEdgeConnection = Mock.ofType(chromeConnection.ChromeConnection);
         mockEdge = getMockEdgeConnectionApi();
         mockEventEmitter = mockEdge.mockEventEmitter;
         mockEdgeConnection
             .setup(x => x.api)
             .returns(() => mockEdge.apiObjects);
-        mockEdgeConnection
-            .setup(x => x.attach(It.isValue(undefined), It.isAnyNumber(), It.isValue(undefined)))
-            .returns(() => Promise.resolve());
         mockEdgeConnection
             .setup(x => x.isAttached)
             .returns(() => isAttached);


### PR DESCRIPTION
Upgrading TypeMoq recently changed the way MockBehavior.Strict works and broke the unit tests