### PR TITLE
Adding check to see if port is occupied

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3953,6 +3953,14 @@
         "kind-of": "^3.0.2"
       }
     },
+    "is-number-like": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+      "requires": {
+        "lodash.isfinite": "^3.3.2"
+      }
+    },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
@@ -4384,6 +4392,11 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
+    "lodash.isfinite": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
+    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -4701,6 +4714,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -4708,7 +4722,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -4748,6 +4763,20 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
           "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
           "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "has-flag": {
           "version": "3.0.0",
@@ -5381,6 +5410,30 @@
           "requires": {
             "ms": "2.0.0"
           }
+        }
+      }
+    },
+    "portscanner": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
+      "integrity": "sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==",
+      "requires": {
+        "async": "^2.6.0",
+        "is-number-like": "^1.0.3"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -7244,29 +7297,6 @@
         "vscode-debugprotocol": "^1.30.0-pre.2",
         "vscode-nls": "^3.2.2",
         "ws": "^3.3.2"
-      },
-      "dependencies": {
-        "vscode-debugadapter": {
-          "version": "1.30.0-pre.2",
-          "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.30.0-pre.2.tgz",
-          "integrity": "sha512-i/2ZzkVdtMbd6TDc0rqJrUeefPPn3D4NJLizshn1IqHvkQsczSgnTT+2snfbnqe+DiFKuS2M9wW69kr7/tE+wQ==",
-          "requires": {
-            "mkdirp": "^0.5.1",
-            "vscode-debugprotocol": "1.30.0-pre.2"
-          },
-          "dependencies": {
-            "vscode-debugprotocol": {
-              "version": "1.30.0-pre.2",
-              "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.30.0-pre.2.tgz",
-              "integrity": "sha512-EE+NDvV5Tgsmv2eDEj0Zi9b8ZzWeoyo9GlMoFTGu6BZ/RyEER07bnCXjmWyLgXF8xklAVzh7S/FhbJE+9dw9ZQ=="
-            }
-          }
-        },
-        "vscode-debugprotocol": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.30.0.tgz",
-          "integrity": "sha512-cWio/bEEiLwaeJ2X7GKzRd/mGmYqnBx1z4CWjP04+W5VDw9RtaqmkSrKsSUdEooYgsuX8kLyZ8ROaJ11dBM0Tg=="
-        }
       }
     },
     "vscode-chrome-debug-core-testsupport": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4714,7 +4714,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -4722,8 +4721,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -7297,6 +7295,29 @@
         "vscode-debugprotocol": "^1.30.0-pre.2",
         "vscode-nls": "^3.2.2",
         "ws": "^3.3.2"
+      },
+      "dependencies": {
+        "vscode-debugadapter": {
+          "version": "1.30.0-pre.2",
+          "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.30.0-pre.2.tgz",
+          "integrity": "sha512-i/2ZzkVdtMbd6TDc0rqJrUeefPPn3D4NJLizshn1IqHvkQsczSgnTT+2snfbnqe+DiFKuS2M9wW69kr7/tE+wQ==",
+          "requires": {
+            "mkdirp": "^0.5.1",
+            "vscode-debugprotocol": "1.30.0-pre.2"
+          },
+          "dependencies": {
+            "vscode-debugprotocol": {
+              "version": "1.30.0-pre.2",
+              "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.30.0-pre.2.tgz",
+              "integrity": "sha512-EE+NDvV5Tgsmv2eDEj0Zi9b8ZzWeoyo9GlMoFTGu6BZ/RyEER07bnCXjmWyLgXF8xklAVzh7S/FhbJE+9dw9ZQ=="
+            }
+          }
+        },
+        "vscode-debugprotocol": {
+          "version": "1.30.0",
+          "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.30.0.tgz",
+          "integrity": "sha512-cWio/bEEiLwaeJ2X7GKzRd/mGmYqnBx1z4CWjP04+W5VDw9RtaqmkSrKsSUdEooYgsuX8kLyZ8ROaJ11dBM0Tg=="
+        }
       }
     },
     "vscode-chrome-debug-core-testsupport": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   ],
   "license": "SEE LICENSE IN LICENSE.txt",
   "dependencies": {
-    "vscode-chrome-debug-core": "^6.4.0",
+    "vscode-chrome-debug-core": "^6.2.2",
+    "portscanner": "^2.2.0",
     "vscode-debugadapter": "^1.28.0",
     "vscode-nls": "^3.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "license": "SEE LICENSE IN LICENSE.txt",
   "dependencies": {
-    "vscode-chrome-debug-core": "^6.2.2",
+    "vscode-chrome-debug-core": "^6.4.0",
     "portscanner": "^2.2.0",
     "vscode-debugadapter": "^1.28.0",
     "vscode-nls": "^3.2.2"

--- a/src/edgeDebugAdapter.ts
+++ b/src/edgeDebugAdapter.ts
@@ -99,7 +99,7 @@ export class EdgeDebugAdapter extends CoreDebugAdapter {
         const port = args.port || 2015;
 
         // Check if the port is being used by another process
-        telemetry.telemetry.reportEvent('startingPortOccupiedCheck', port);
+        this.events.emitStepStarted('Launch.CheckWhetherPortOccupied');
         await this._checkPortOccupied(args.address, port);
 
         return super.launch(args).then(() => {

--- a/src/edgeDebugAdapter.ts
+++ b/src/edgeDebugAdapter.ts
@@ -67,7 +67,7 @@ export class EdgeDebugAdapter extends CoreDebugAdapter {
         const url = `http://${address}:${port}/json/version`;
         logger.log(`Checking if EDP is running on the port by hitting ${url}`);
 
-        const jsonResponse = await utils.getURL(url, { headers: { Host: 'localhost' } })
+        const jsonResponse = await coreUtils.getURL(url, { headers: { Host: 'localhost' } })
             .catch(e => {
                 // This means /json/version is not available. So the port is being used by another process.
                 // Error out in this case.
@@ -91,6 +91,7 @@ export class EdgeDebugAdapter extends CoreDebugAdapter {
             }
         }, err => {
             logger.log(`There was an error trying to verify port usage: ${err}`);
+            telemetry.telemetry.reportEvent('errorCheckingPortOccupied', err);
         });
     }
 
@@ -98,6 +99,7 @@ export class EdgeDebugAdapter extends CoreDebugAdapter {
         const port = args.port || 2015;
 
         // Check if the port is being used by another process
+        telemetry.telemetry.reportEvent('startingPortOccupiedCheck', port);
         await this._checkPortOccupied(args.address, port);
 
         return super.launch(args).then(() => {

--- a/src/edgeDebugAdapter.ts
+++ b/src/edgeDebugAdapter.ts
@@ -73,7 +73,7 @@ export class EdgeDebugAdapter extends CoreDebugAdapter {
                 // Error out in this case.
                 logger.log(`There was an error connecting to ${url} : ${e.message}`);
                 telemetry.telemetry.reportEvent('portOccupiedByAnotherProcess', port);
-                return coreUtils.errP(localize('edge.port.occupied', 'Cannot launch Edge. The specified debugging port {0} is in use by another process.', port));
+                return coreUtils.errP(localize('edge.port.occupied', 'Cannot launch Edge. The specified debugging port {0} is in use by another process. To continue debugging please make sure no process is running on the port.', port));
             });
 
         // If we reach here that means EDP is running on the port, so we can continue
@@ -91,7 +91,7 @@ export class EdgeDebugAdapter extends CoreDebugAdapter {
             }
         }, err => {
             logger.log(`There was an error trying to verify port usage: ${err}`);
-            telemetry.telemetry.reportEvent('errorCheckingPortOccupied', err);
+            telemetry.telemetry.reportEvent('errorCheckingDebuggingPortOccupiedByAnotherProcess', err);
         });
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,10 @@
  *--------------------------------------------------------*/
 
 import * as os from 'os';
+import * as https from 'https';
+import * as http from 'http';
+import { logger } from 'vscode-debugadapter';
+import * as url from 'url';
 import {utils as coreUtils, chromeConnection} from 'vscode-chrome-debug-core';
 
 export function isEdgeDebuggingSupported(): boolean {
@@ -26,3 +30,35 @@ export function getEdgePath(): string {
 
 export const targetFilter: chromeConnection.ITargetFilter =
     target => target && (!target.type || target.type === 'page' || target.type === 'Page');
+
+/**
+ * Helper function to GET the contents of a url
+ */
+export function getURL(aUrl: string, options: https.RequestOptions = {}): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const parsedUrl = url.parse(aUrl);
+        const get = parsedUrl.protocol === 'https:' ? https.get : http.get;
+        options = <https.RequestOptions>{
+            rejectUnauthorized: false,
+            ...parsedUrl,
+            ...options
+        };
+
+        get(options, response => {
+            let responseData = '';
+            response.on('data', chunk => responseData += chunk);
+            response.on('end', () => {
+                // Sometimes the 'error' event is not fired. Double check here.
+                if (response.statusCode === 200) {
+                    resolve(responseData);
+                } else {
+                    logger.log('HTTP GET failed with: ' + response.statusCode.toString() + ' ' + response.statusMessage.toString());
+                    reject(new Error(responseData.trim()));
+                }
+            });
+        }).on('error', e => {
+            logger.log('HTTP GET failed: ' + e.toString());
+            reject(e);
+        });
+    });
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,10 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as os from 'os';
-import * as https from 'https';
-import * as http from 'http';
-import { logger } from 'vscode-debugadapter';
-import * as url from 'url';
 import {utils as coreUtils, chromeConnection} from 'vscode-chrome-debug-core';
 
 export function isEdgeDebuggingSupported(): boolean {
@@ -30,35 +26,3 @@ export function getEdgePath(): string {
 
 export const targetFilter: chromeConnection.ITargetFilter =
     target => target && (!target.type || target.type === 'page' || target.type === 'Page');
-
-/**
- * Helper function to GET the contents of a url
- */
-export function getURL(aUrl: string, options: https.RequestOptions = {}): Promise<string> {
-    return new Promise((resolve, reject) => {
-        const parsedUrl = url.parse(aUrl);
-        const get = parsedUrl.protocol === 'https:' ? https.get : http.get;
-        options = <https.RequestOptions>{
-            rejectUnauthorized: false,
-            ...parsedUrl,
-            ...options
-        };
-
-        get(options, response => {
-            let responseData = '';
-            response.on('data', chunk => responseData += chunk);
-            response.on('end', () => {
-                // Sometimes the 'error' event is not fired. Double check here.
-                if (response.statusCode === 200) {
-                    resolve(responseData);
-                } else {
-                    logger.log('HTTP GET failed with: ' + response.statusCode.toString() + ' ' + response.statusMessage.toString());
-                    reject(new Error(responseData.trim()));
-                }
-            });
-        }).on('error', e => {
-            logger.log('HTTP GET failed: ' + e.toString());
-            reject(e);
-        });
-    });
-}


### PR DESCRIPTION
We now check before launch that the user specified port(for VS Code) or 2015 port given by VS is used by another process. If it's used by EDP, we continue with the launch, if not it errors out with a message.

I thought about whether to make this change in core to save the duplication of code but I didn't do it for the following reasons:

1. I would had to make platform specific checks in core to see whether the port is occupied by Edge/Chrome or Node to decide whether we can launch or not. I wanted to avoid it. 
2. The reason we have to do /json/version call to verify if EDP is using that port is because if EDP is indeed running on the port, it runs under the 'System' process name and we can't just perform the verification by using the process name. This is not the case for Chrome and node. 
3. This way we can give platform specific error messages to the user. This is possible in core as well but not without platform checks which again I wanted to avoid.

