### PR TITLE
Use new API on RS5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6862,9 +6862,9 @@
       }
     },
     "vscode-chrome-debug-core": {
-      "version": "6.7.7",
-      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.7.7.tgz",
-      "integrity": "sha512-2DRx1lCXqLkwI4QfTzu8YH+Ko53wyZBstRKxG+UI/lV5WsoLWPZK/egdlC2DYxP//7WZ5PVOadBjBTMDiFIgdA==",
+      "version": "6.7.9",
+      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.7.9.tgz",
+      "integrity": "sha512-U5TP6y+i+Ldg2ElDPm16tdHc7U5i2LzcGzMQFS3r+w6wrlqDEU7jMV8YIixVB5A7xIGMCtiNh3nL9zxgunV89w==",
       "requires": {
         "@types/source-map": "^0.1.27",
         "devtools-protocol": "0.0.574367",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "SEE LICENSE IN LICENSE.txt",
   "dependencies": {
     "portscanner": "^2.2.0",
-    "vscode-chrome-debug-core": "^6.7.7",
+    "vscode-chrome-debug-core": "^6.7.8",
     "vscode-debugadapter": "^1.31.0-pre.0",
     "vscode-nls": "^3.2.2"
   },

--- a/src/edgeVariablesContainer.ts
+++ b/src/edgeVariablesContainer.ts
@@ -19,7 +19,7 @@ export interface ExtendedDebugProtocolVariable extends DebugProtocol.Variable {
 export class MSPropertyContainer extends variables.PropertyContainer {
     private _childPropertiesMapping: Map<string, string>;
 
-    public constructor(objectId: string, evaluateName?: string) {
+    public constructor(objectId: string, private _useRuntimeCallFunctionOnForAllVariables: boolean, evaluateName?: string) {
         super(objectId, evaluateName);
 
         this._childPropertiesMapping = new Map<string, string>();
@@ -44,7 +44,7 @@ export class MSPropertyContainer extends variables.PropertyContainer {
     public async setValue(adapter: EdgeDebugAdapter, name: string, value: string): Promise<string> {
         const msDebuggerPropertyId = this._childPropertiesMapping.get(name);
 
-        if (!msDebuggerPropertyId) {
+        if (this._useRuntimeCallFunctionOnForAllVariables || !msDebuggerPropertyId) {
             // If msDebuggerPropertyId is not present, default to super setValue for this variable.
             await super.setValue(adapter, name, value)
                 .catch(() => {

--- a/test/edgeDebugAdapter.test.ts
+++ b/test/edgeDebugAdapter.test.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 
 import {DebugProtocol} from 'vscode-debugprotocol';
-import {chromeConnection, ISourceMapPathOverrides} from 'vscode-chrome-debug-core';
+import {chromeConnection, ISourceMapPathOverrides, ProtocolSchema} from 'vscode-chrome-debug-core';
 
 import * as mockery from 'mockery';
 import {EventEmitter} from 'events';
@@ -50,7 +50,7 @@ suite('EdgeDebugAdapter', () => {
             .returns(() => isAttached);
         mockEdgeConnection
             .setup(x => x.attachedTarget)
-            .returns(() => ({ description: "", devtoolsFrontendUrl: "", id: "", title: "", type: "", webSocketDebuggerUrl: "" }));
+            .returns(() => ({ description: "", devtoolsFrontendUrl: "", id: "", title: "", type: "", webSocketDebuggerUrl: "", version: Promise.resolve(new ProtocolSchema(0, 0)) }));
         mockEdgeConnection
             .setup(x => x.run())
             .returns(() => Promise.resolve());


### PR DESCRIPTION
Depends on this -core change: https://github.com/Microsoft/vscode-chrome-debug-core/pull/348

In RS5: we revert to use the chrome apis instead of the custom msDebuggerPropertyId property and API