### PR TITLE
work around for edge to catch non-existent watch variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6859,9 +6859,9 @@
       }
     },
     "vscode-chrome-debug-core": {
-      "version": "6.7.18",
-      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.7.18.tgz",
-      "integrity": "sha512-VKD96W1likS77wVFuoSjNc6oS8nOHh+JM+7MPriGQdDCD2gDoroNItHvZNXHtGa3eWxIIWkXVvLiAYcrgIBHBA==",
+      "version": "6.7.19",
+      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.7.19.tgz",
+      "integrity": "sha512-JEiUNKRB9ZEQ3ghDYkM5YrnCvY965KjShGiNN/jkrDzdFyMVz2ZN2Az4i1pbdLHHHD5eaheF7v1dNnV8hsqAZA==",
       "requires": {
         "@types/source-map": "^0.1.27",
         "devtools-protocol": "0.0.588169",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "SEE LICENSE IN LICENSE.txt",
   "dependencies": {
     "portscanner": "^2.2.0",
-    "vscode-chrome-debug-core": "^6.7.18",
+    "vscode-chrome-debug-core": "^6.7.19",
     "vscode-debugadapter": "^1.31.0",
     "vscode-nls": "^3.2.2"
   },

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { ErrorWithMessage } from 'vscode-chrome-debug-core/out/src/errors';
+import * as chromeDebugErrors from 'vscode-chrome-debug-core/out/src/errors';
 
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -12,9 +12,11 @@ const localize = nls.loadMessageBundle();
  * 'Path does not exist' error
  */
 export function getNotExistErrorResponse(attribute: string, path: string): Promise <void> {
-    return Promise.reject(new ErrorWithMessage(<DebugProtocol.Message>{
+    return Promise.reject(new chromeDebugErrors.ErrorWithMessage(<DebugProtocol.Message>{
         id: 2007,
         format: localize('attribute.path.not.exist', "Attribute '{0}' does not exist ('{1}').", attribute, '{path}'),
         variables: { path }
     }));
 }
+
+export const evalNotAvailableMsg = chromeDebugErrors.evalNotAvailableMsg;

--- a/test/edgeDebugAdapter.test.ts
+++ b/test/edgeDebugAdapter.test.ts
@@ -134,9 +134,9 @@ suite('EdgeDebugAdapter', () => {
     });
 
     suite('evaluate()', () => {
-        let frameHandle_beforeOverride: any;
-        let chromeDebuggerEvaluateOnCallFrame_beforeOverride: any;
-        let remoteObjectToVariable_beforeOverride: any;
+        let frameHandle_beforeOverride;
+        let chromeDebuggerEvaluateOnCallFrame_beforeOverride;
+        let remoteObjectToVariable_beforeOverride;
 
         teardown(() => {
             // also hacky cleanup...


### PR DESCRIPTION
if watch variable comes back from chrome-debug-core's evaluate as empty, return it as an error (because that is what chrome adapter is doing) instead of as an empty string, so not available message shows up