### PR TITLE
when selecting a tab, use websocket to get version

### DIFF
--- a/src/edgeDebugAdapter.ts
+++ b/src/edgeDebugAdapter.ts
@@ -230,8 +230,14 @@ export class EdgeDebugAdapter extends CoreDebugAdapter {
                 return properties;
             });
 
-            let protocolVersion: TargetVersions = await this._chromeConnection.version;
-            // this._chromeConnection.version is never undefined (will always be at least 0.0)
+            // protocolVersion depends on chrome connection having attached target, but it should never be undefined (should always be at least 0.0)
+            let protocolVersion: TargetVersions;
+            if (this._chromeConnection.attachedTarget) {
+                protocolVersion = await this._chromeConnection.version;
+            } else {
+                protocolVersion = new TargetVersions(Version.unknownVersion(), Version.unknownVersion());
+            }
+
             this._edgeProtocolVersion = protocolVersion.protocol;
 
             // Send the versions information as it's own event so we can easily backfill other events in the user session if needed

--- a/src/edgeDebugAdapter.ts
+++ b/src/edgeDebugAdapter.ts
@@ -213,8 +213,8 @@ export class EdgeDebugAdapter extends CoreDebugAdapter {
     }
 
     private processEDPProtocolVersion(version: string): Version {
-        // version strings from websocket protocol are in the form "v0.2" with a prepended "v"
-        // EDP api has a bug in it that version 0.1 of EDP actually returns "v1.2", and they don't plan on fixing it, so here's a check for it
+        // version strings from EDP api are in the form "v0.2" with a prepended "v"
+        // EDP api has a bug in it in that version 0.1 of EDP actually returns "v1.2", and they don't plan on fixing it, so here's a check for it
         if (version === "v1.2") {
             return Version.parse("0.1");
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,11 @@ export class EdgeConfigurationProvider implements vscode.DebugConfigurationProvi
                     return null;
                 }
 
-                config.websocketUrl = selectedTarget.websocketDebuggerUrl;
+                if (selectedTarget.detail) {
+                    config.url = selectedTarget.detail;
+                } else {
+                    config.websocketUrl = selectedTarget.detail;
+                }
             }
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,11 +68,7 @@ export class EdgeConfigurationProvider implements vscode.DebugConfigurationProvi
                     return null;
                 }
 
-                if (selectedTarget.detail) {
-                    config.url = selectedTarget.detail;
-                } else {
-                    config.websocketUrl = selectedTarget.detail;
-                }
+                config.websocketUrl = selectedTarget.detail;
             }
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,7 @@ export class EdgeConfigurationProvider implements vscode.DebugConfigurationProvi
                     return null;
                 }
 
-                config.websocketUrl = selectedTarget.detail;
+                config.websocketUrl = selectedTarget.websocketDebuggerUrl;
             }
         }
 

--- a/test/debugProtocolMocks.ts
+++ b/test/debugProtocolMocks.ts
@@ -19,6 +19,7 @@ export interface IMockEdgeConnectionAPI {
     Network: IMock<Crdp.NetworkApi>;
     Page: IMock<Crdp.PageApi>;
     Log: IMock<Crdp.LogApi>;
+    Schema: IMock<Crdp.SchemaApi>;
 
     mockEventEmitter: EventEmitter;
 }
@@ -87,6 +88,12 @@ function getLogStubs() {
     };
 }
 
+function getSchemaStubs() {
+    return {
+        getDomains() { return Promise.resolve({domains: []})}
+    }
+}
+
 export function getMockEdgeConnectionApi(): IMockEdgeConnectionAPI {
     const mockEventEmitter = new EventEmitter();
 
@@ -125,6 +132,9 @@ export function getMockEdgeConnectionApi(): IMockEdgeConnectionAPI {
     const mockBrowser = Mock.ofInstance<Crdp.BrowserApi>(<any>getBrowserStubs());
     mockBrowser.callBase = true;
 
+    const mockSchema = Mock.ofInstance<Crdp.SchemaApi>(<any>getSchemaStubs());
+    mockSchema.callBase = true;
+
     const edgeConnectionAPI: Crdp.ProtocolApi = <any>{
         Browser: mockBrowser.object,
         Console: mockConsole.object,
@@ -133,7 +143,8 @@ export function getMockEdgeConnectionApi(): IMockEdgeConnectionAPI {
         Inspector: mockInspector.object,
         Network: mockNetwork.object,
         Page: mockPage.object,
-        Log: mockLog.object
+        Log: mockLog.object,
+        Schema: mockSchema.object
     };
 
     return {
@@ -147,6 +158,7 @@ export function getMockEdgeConnectionApi(): IMockEdgeConnectionAPI {
         Network: mockNetwork,
         Page: mockPage,
         Log: mockLog,
+        Schema: mockSchema,
 
         mockEventEmitter
     };


### PR DESCRIPTION
This is so that when a user does not provide a url, and selects a tab, we can detect the tab that they are trying to debug