### PR TITLE
Add support for launching an application using WebView2

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}",
             // "program": "${workspaceFolder}/out/src/legacyEdge/edgeDebug.js",
-            "program": "${workspaceFolder}/out/src/chromeDebug.js",
+            "program": "${workspaceFolder}/out/src/edgeChromiumDebug.js",
             "args": [ "--server=4712" ],
             "outFiles": ["${workspaceFolder}/out/**/*.js"]
         },

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The example `launch.json` config below will attach to either Microsoft Edge (Chr
 
 ### Other optional launch config fields
 * `trace`: When true, the adapter logs its own diagnostic info to a file. The file path will be printed in the Debug Console. This is often useful info to include when filing an issue on GitHub. If you set it to "verbose", it will log to a file and also log to the console.
-* `version`: When set to `canary`, `dev`, or `beta`, it will launch the matching version of Microsoft Edge (Chromium). If not specificed, Microsoft Edge (EdgeHTML) will be launched.
+* `version`: When set to `canary`, `dev`, or `beta`, it will launch the matching version of Microsoft Edge (Chromium). If not specified, Microsoft Edge (EdgeHTML) will be launched.
 * `runtimeExecutable`: Workspace relative or absolute path to the runtime executable to be used. If not specified, Microsoft Edge (EdgeHTML) will be used from the default install location.
 * `runtimeArgs`: Optional arguments passed to the runtime executable.
 * `env`: Optional dictionary of environment key/value pairs.
@@ -124,6 +124,14 @@ The example `launch.json` config below will attach to either Microsoft Edge (Chr
 * `smartStep`: Automatically steps over code that doesn't map to source files. Especially useful for debugging with async/await.
 * `disableNetworkCache`: If true, the network cache will be disabled.
 * `showAsyncStacks`: If true, callstacks across async calls (like `setTimeout`, `fetch`, resolved Promises, etc) will be shown.
+* `useWebView`: If true, the debugger will treat the `runtimeExecutable` as an application hosting a WebView. See: [Microsoft Edge (Chromium) WebView applications](#Microsoft-Edge-(Chromium)-WebView-applications)
+
+### Microsoft Edge (Chromium) WebView applications
+You can also use the debugger to launch applications that are using an embedded [Microsoft Edge (Chromium) WebView](https://docs.microsoft.com/en-us/microsoft-edge/hosting/webview2). With the correct `launch.json` properties, the debugger will launch your host application and attach to the WebView allowing you to debug the running script content.
+
+To use the debugger against a WebView application use the following properties in your launch config:
+* `runtimeExecutable`: Set this to the full path to your host application.
+* `useWebView`: Set this to be `true`
 
 ### Other targets
 You can also theoretically attach to other targets that support the same [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/tot) as the Microsoft Edge (Chromium) browser, such as Electron or Cordova. These aren't officially supported, but should work with basically the same steps. You can use a launch config by setting `"runtimeExecutable"` to a program or script to launch, or an attach config to attach to a process that's already running. If Code can't find the target, you can always verify that it is actually available by navigating to `http://localhost:<port>/json` in a browser. If you get a response with a bunch of JSON, and can find your target page in that JSON, then the target should be available to this extension.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "scripts": {
     "build": "gulp build",
     "watch": "gulp watch",
-    "start": "node out/src/chromeDebug.js --server=4712",
+    "start": "node out/src/edgeChromiumDebug.js --server=4712",
     "test:legacy-edge": "mocha --exit --timeout 20000 -s 2000 -u tdd --colors \"./out/test/legacyEdge/test/*.test.js\"",
     "test:msedge": "mocha --exit --timeout 20000 -s 2000 -u tdd --colors \"./out/test/*.test.js\"",
     "test": "npm run test:legacy-edge && npm run test:msedge",
@@ -107,7 +107,7 @@
       {
         "type": "msedge",
         "label": "MsEdge",
-        "program": "./out/src/chromeDebug.js",
+        "program": "./out/src/edgeChromiumDebug.js",
         "runtime": "node",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
         "languages": [

--- a/package.json
+++ b/package.json
@@ -327,6 +327,13 @@
                 "default": [
                   "page"
                 ]
+              },
+              "useWebView": {
+                "type": [
+                  "boolean"
+                ],
+                "description": "%edge.useWebView.description%",
+                "default": false
               }
             }
           },
@@ -438,6 +445,13 @@
                 "type": "boolean",
                 "description": "%edge.logTimestamps.description%",
                 "default": true
+              },
+              "useWebView": {
+                "type": [
+                  "boolean"
+                ],
+                "description": "%edge.useWebView.description%",
+                "default": false
               }
             }
           }

--- a/package.nls.cs.json
+++ b/package.nls.cs.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -31,5 +31,6 @@
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Microsoft Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
 	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
 	"edge.breakOnLoadStrategy.off.description": "Turns off breakOnLoad.",
-	"edge.targetTypes.description": "An array of acceptable target types. The default is `[\"page\"]`."
+	"edge.targetTypes.description": "An array of acceptable target types. The default is `[\"page\"]`.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.ko.json
+++ b/package.nls.ko.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.pl.json
+++ b/package.nls.pl.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.tr.json
+++ b/package.nls.tr.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -28,5 +28,6 @@
 	"edge.breakOnLoad.description": "Experimental feature -  If true, the debug adapter will attempt to set breakpoints in scripts before they are loaded, so it can hit breakpoints at the beginnings of those scripts. Has a perf impact.",
 	"edge.breakOnLoadStrategy.description": "The strategy to use for breakOnLoad.",
 	"edge.breakOnLoadStrategy.instrument.description": "Tell Edge to pause as each script is loaded, resolving sourcemaps and setting breakpoints",
-	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set."
+	"edge.breakOnLoadStrategy.regex.description": "Sets breakpoints optimistically in files with the same name as the file in which the breakpoint is set.",
+	"edge.useWebView.description": "When 'true', the debugger will treat the runtime executable as a host application that contains a WebView allowing you to debug the WebView script content."
 }

--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -40,6 +40,7 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
     private _chromePID: number;
     private _userRequestedUrl: string;
     private _doesHostSupportLaunchUnelevatedProcessRequest: boolean;
+    private _isDebuggerUsingWebView: boolean;
 
     public initialize(args: IExtendedInitializeRequestArguments): VSDebugProtocolCapabilities {
         this._overlayHelper = new utils.DebounceHelper(/*timeoutMs=*/200);
@@ -132,15 +133,29 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
                 launchUrl = args.url;
             }
 
-            if (launchUrl && !args.noDebug) {
+            if (launchUrl && !args.noDebug && !args.useWebView) {
                 // We store the launch file/url provided and temporarily launch and attach to about:blank page. Once we receive configurationDone() event, we redirect the page to this file/url
-                // This is done to facilitate hitting breakpoints on load
+                // This is done to facilitate hitting breakpoints on load.
+                // We only do this for the browser. WebView applications will instead auto issue an internal Page.waitForDebugger command when launched for debugging so we have time to bind bps.
                 this._userRequestedUrl = launchUrl;
                 launchUrl = 'about:blank';
             }
 
             if (launchUrl) {
                 chromeArgs.push(launchUrl);
+            }
+
+            this._isDebuggerUsingWebView = args.useWebView;
+            if (args.useWebView) {
+                telemetryPropertyCollector.addTelemetryProperty('useWebView', 'true');
+
+                // Initialize WebView debugging environment variables
+                if (!args.userDataDir) {
+                    args.userDataDir = path.join(os.tmpdir(), `vscode-edge-debug-userdatadir_${port}`);
+                }
+                chromeEnv['WEBVIEW2_USER_DATA_FOLDER'] = args.userDataDir.toString();
+                chromeEnv['WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS'] = `--remote-debugging-port=${port}`;
+                chromeEnv['WEBVIEW2_WAIT_FOR_SCRIPT_DEBUGGER'] = `true`;
             }
 
             this._chromeProc = await this.spawnChrome(runtimeExecutable, chromeArgs, chromeEnv, chromeWorkingDir, !!args.runtimeExecutable,
@@ -154,7 +169,7 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
             }
 
             return args.noDebug ? undefined :
-                this.doAttach(port, launchUrl || args.urlFilter, args.address, args.timeout, undefined, args.extraCRDPChannelPort);
+                this.doAttach(port, launchUrl || args.urlFilter, args.address, args.timeout, undefined, args.extraCRDPChannelPort, args.useWebView);
         });
     }
 
@@ -225,7 +240,7 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
         super.commonArgs(args);
     }
 
-    protected doAttach(port: number, targetUrl?: string, address?: string, timeout?: number, websocketUrl?: string, extraCRDPChannelPort?: number): Promise<void> {
+    protected doAttach(port: number, targetUrl?: string, address?: string, timeout?: number, websocketUrl?: string, extraCRDPChannelPort?: number, useWebView?: boolean): Promise<void> {
         return super.doAttach(port, targetUrl, address, timeout, websocketUrl, extraCRDPChannelPort).then(async () => {
             // Don't return this promise, a failure shouldn't fail attach
             this.globalEvaluate({ expression: 'navigator.userAgent', silent: true })
@@ -307,6 +322,11 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
                 telemetry.telemetry.reportEvent('break-on-load-target-version-workaround-failed', exception);
             }
 
+            if (useWebView) {
+                // For WebViews we must issue the runIfWaitingForDebugger command once we are attached, to resume script execution
+                this.chrome.Runtime.runIfWaitingForDebugger();
+            }
+
             /* __GDPR__FRAGMENT__
                 "DebugCommonProperties" : {
                     "${include}": [ "${VersionInformation}" ]
@@ -317,11 +337,26 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
     }
 
     protected runConnection(): Promise<void>[] {
-        return [
-            ...super.runConnection(),
-            this.chrome.Page.enable(),
-            this.chrome.Network.enable({})
-        ];
+        if (!this._isDebuggerUsingWebView) {
+            return [
+                ...super.runConnection(),
+                this.chrome.Page.enable(),
+                this.chrome.Network.enable({})
+            ];
+        } else {
+            // For WebView we must no call super.runConnection() since that will cause the execution to resume before we are ready.
+            // Instead we strip out the call to _chromeConnection.run() and call runIfWaitingForDebugger() once attach is complete.
+            return [
+                this.chrome.Console.enable()
+                    .catch(e => { }),
+                this.chrome.Debugger.enable() as any,
+                this.chrome.Runtime.enable(),
+                this.chrome.Log.enable()
+                    .catch(e => { }),
+                this.chrome.Page.enable(),
+                this.chrome.Network.enable({}),
+            ];
+        }
     }
 
     protected async onPaused(notification: Crdp.Debugger.PausedEvent, expectingStopReason = this._expectingStopReason): Promise<IOnPausedResult> {

--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -81,6 +81,9 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
                     return errors.getNotExistErrorResponse('runtimeExecutable', args.runtimeExecutable);
                 }
                 runtimeExecutable = re;
+            } else if (args.useWebView) {
+                // Users must specify the host application via runtimeExecutable when using webview
+                return errors.incorrectFlagMessage('runtimeExecutable', 'Must be set when using \'useWebView\'');
             } else if (args['version']){
                 runtimeExecutable = utils.getBrowserPath(args['version']);
             }

--- a/src/chromeDebugInterfaces.d.ts
+++ b/src/chromeDebugInterfaces.d.ts
@@ -27,6 +27,7 @@ export interface ILaunchRequestArgs extends Core.ILaunchRequestArgs, ICommonRequ
     breakOnLoad?: boolean;
     _clientOverlayPausedMessage?: string;
     shouldLaunchEdgeUnelevated?: boolean;
+    useWebView?: boolean;
 }
 
 export interface IAttachRequestArgs extends Core.IAttachRequestArgs, ICommonRequestArgs {

--- a/src/edgeChromiumDebug.ts
+++ b/src/edgeChromiumDebug.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ChromeDebugSession, logger, UrlPathTransformer, BaseSourceMapTransformer, telemetry } from 'vscode-chrome-debug-core';
+import * as path from 'path';
+import * as os from 'os';
+import { defaultTargetFilter } from './utils';
+
+import { EdgeChromiumDebugAdapter } from './edgeChromiumDebugAdapter';
+
+const EXTENSION_NAME = 'debugger-for-edge';
+
+// Start a ChromeDebugSession configured to only match 'page' targets, which are Chrome tabs.
+// Cast because DebugSession is declared twice - in this repo's vscode-debugadapter, and that of -core... TODO
+ChromeDebugSession.run(ChromeDebugSession.getSession(
+    {
+        adapter: EdgeChromiumDebugAdapter,
+        extensionName: EXTENSION_NAME,
+        logFilePath: path.resolve(os.tmpdir(), 'vscode-edge-debug.txt'),
+        targetFilter: defaultTargetFilter,
+
+        pathTransformer: UrlPathTransformer,
+        sourceMapTransformer: BaseSourceMapTransformer,
+    }));
+
+/* tslint:disable:no-var-requires */
+const debugAdapterVersion = require('../../package.json').version;
+logger.log(EXTENSION_NAME + ': ' + debugAdapterVersion);
+
+/* __GDPR__FRAGMENT__
+    "DebugCommonProperties" : {
+        "Versions.DebugAdapter" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+    }
+*/
+telemetry.telemetry.addCustomGlobalProperty({'Versions.DebugAdapter': debugAdapterVersion});

--- a/src/edgeChromiumDebugAdapter.ts
+++ b/src/edgeChromiumDebugAdapter.ts
@@ -1,0 +1,87 @@
+
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as os from 'os';
+import * as path from 'path';
+
+import { ChromeDebugAdapter } from './chromeDebugAdapter';
+import { ITelemetryPropertyCollector, utils as coreUtils } from 'vscode-chrome-debug-core';
+import { ILaunchRequestArgs } from './chromeDebugInterfaces';
+import * as errors from './errors';
+
+export class EdgeChromiumDebugAdapter extends ChromeDebugAdapter {
+    private _isDebuggerUsingWebView: boolean;
+
+    public async launch(args: ILaunchRequestArgs, telemetryPropertyCollector: ITelemetryPropertyCollector, seq?: number) {
+        let attachToWebView = false;
+
+        if (args.useWebView) {
+            if (!args.runtimeExecutable) {
+                // Users must specify the host application via runtimeExecutable when using webview
+                return errors.incorrectFlagMessage('runtimeExecutable', 'Must be set when using \'useWebView\'');
+            }
+
+            telemetryPropertyCollector.addTelemetryProperty('useWebView', 'true');
+            this._isDebuggerUsingWebView = true;
+
+            // Initialize WebView debugging environment variables
+            args.port = args.port || 2015;
+            if (!args.userDataDir) {
+                args.userDataDir = path.join(os.tmpdir(), `vscode-edge-debug-userdatadir_${args.port}`);
+            }
+            args.env = args.env || {};
+            args.env['WEBVIEW2_USER_DATA_FOLDER'] = args.userDataDir.toString();
+            args.env['WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS'] = `--remote-debugging-port=${args.port}`;
+            args.env['WEBVIEW2_WAIT_FOR_SCRIPT_DEBUGGER'] = `true`;
+
+            // To ensure the ChromeDebugAdapter does not override the launchUrl for WebView we force noDebug=true.
+            attachToWebView = !args.noDebug;
+            args.noDebug = true;
+        }
+
+        await super.launch(args, telemetryPropertyCollector, seq);
+        if (attachToWebView) {
+            // If we are debugging a WebView, we need to attach to it after launch.
+            // Since the ChromeDebugAdapter will have been called with noDebug=true,
+            // it will not have auto attached during the super.launch() call.
+            let launchUrl: string;
+            if (args.file) {
+                launchUrl = coreUtils.pathToFileURL(args.file);
+            } else if (args.url) {
+                launchUrl = args.url;
+            }
+
+            this.doAttach(args.port, launchUrl || args.urlFilter, args.address, args.timeout, undefined, args.extraCRDPChannelPort);
+        }
+    }
+
+    protected async doAttach(port: number, targetUrl?: string, address?: string, timeout?: number, websocketUrl?: string, extraCRDPChannelPort?: number) {
+        await super.doAttach(port, targetUrl, address, timeout, websocketUrl, extraCRDPChannelPort);
+
+        if (this._isDebuggerUsingWebView) {
+            // For WebViews we must issue the runIfWaitingForDebugger command once we are attached, to resume script execution
+            this.chrome.Runtime.runIfWaitingForDebugger();
+        }
+    }
+
+    protected runConnection(): Promise<void>[] {
+        if (!this._isDebuggerUsingWebView) {
+            super.runConnection();
+        } else {
+            // For WebView we must no call super.runConnection() since that will cause the execution to resume before we are ready.
+            // Instead we strip out the call to _chromeConnection.run() and call runIfWaitingForDebugger() once attach is complete.
+            return [
+                this.chrome.Console.enable()
+                    .catch(e => { }),
+                this.chrome.Debugger.enable() as any,
+                this.chrome.Runtime.enable(),
+                this.chrome.Log.enable()
+                    .catch(e => { }),
+                this.chrome.Page.enable(),
+                this.chrome.Network.enable({}),
+            ];
+        }
+    }
+}

--- a/test/edgeChromiumDebugAdapter.test.ts
+++ b/test/edgeChromiumDebugAdapter.test.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { EventEmitter } from 'events';
+import * as mockery from 'mockery';
+import { chromeConnection, ISourceMapPathOverrides, telemetry, TargetVersions, Version } from 'vscode-chrome-debug-core';
+import { EdgeChromiumDebugAdapter as _EdgeChromiumDebugAdapter } from '../src/edgeChromiumDebugAdapter';
+import * as testUtils from './testUtils';
+
+
+
+const MODULE_UNDER_TEST = '../src/edgeChromiumDebugAdapter';
+suite('EdgeChromiumDebugAdapter', () => {
+    let edgeChromiumDebugAdapter: _EdgeChromiumDebugAdapter;
+    let mockLaunch: (args: any) => void;
+    let mockDoAttach: () => void;
+    let mockRun: () => void;
+
+    setup(() => {
+        testUtils.setupUnhandledRejectionListener();
+        testUtils.registerLocMocks();
+        mockery.enable({ useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false });
+
+        mockLaunch = () => { };
+        mockDoAttach = () => { };
+        mockRun = () => { };
+
+        mockery.registerMock('./chromeDebugAdapter', {
+            ChromeDebugAdapter: class ChromeDebugAdapter {
+                protected chrome: any;
+                constructor() {
+                    this.chrome = { Runtime: { runIfWaitingForDebugger: () => { mockRun(); } } }
+                }
+                launch(a) { mockLaunch(a); }
+                doAttach() { mockDoAttach(); }
+            }
+        });
+
+        // Instantiate the ChromeDebugAdapter, injecting the mock ChromeConnection
+        const eCDAClass: typeof _EdgeChromiumDebugAdapter = require(MODULE_UNDER_TEST).EdgeChromiumDebugAdapter;
+        edgeChromiumDebugAdapter = new eCDAClass(null, null);
+    });
+
+    teardown(() => {
+        testUtils.removeUnhandledRejectionListener();
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+
+    suite('launch()', () => {
+        let launchCount: number;
+        let launchArgs: any;
+        let attachCount: number;
+        let runCount: number;
+
+        setup(() => {
+            launchCount = 0;
+            launchArgs = {};
+            attachCount = 0;
+            runCount = 0;
+
+            mockLaunch = (args: any) => {
+                launchArgs = args;
+                launchCount++;
+            };
+            mockDoAttach = () => {
+                attachCount++;
+            };
+            mockRun = () => {
+                runCount++;
+            };
+        });
+
+        teardown(() => {
+        });
+
+        test('launches with webview', async () => {
+            await edgeChromiumDebugAdapter.launch({
+                runtimeExecutable: 'webview.exe',
+                useWebView: true,
+            }, new telemetry.TelemetryPropertyCollector());
+
+            assert(launchCount === 1);
+            assert(launchArgs.noDebug);
+            assert(launchArgs.env['WEBVIEW2_USER_DATA_FOLDER']);
+            assert(launchArgs.env['WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS']);
+            assert(launchArgs.env['WEBVIEW2_WAIT_FOR_SCRIPT_DEBUGGER']);
+            assert(attachCount === 1);
+            assert(runCount === 1);
+        });
+
+        test('launches without webview', async () => {
+            await edgeChromiumDebugAdapter.launch({
+            }, new telemetry.TelemetryPropertyCollector());
+
+            assert(launchCount === 1);
+            assert(launchArgs.env === undefined);
+            assert(attachCount === 0);
+            assert(runCount === 0);
+        });
+    });
+});


### PR DESCRIPTION
This PR adds support for using the debugger against an application using an embedded [WebView2](https://docs.microsoft.com/en-us/microsoft-edge/hosting/webview2).

The code adds a new optional property to the launch.json called `useWebView` which when set to true causes the launch procedure to take additional steps. When the using a WebView, the launch function will set the appropriate environment variables for the `runtimeExecutable` so that debugging is enabled and script execution pauses on startup. The attach and runConnection functions are then altered so that script execution on the WebView is resumed once any startup breakpoints have been bound.

* Added new `useWebView` property to launch config
* Added code to set WebView environment variables for debugging
* Updated package.json and readme with instructions for WebView2
