### PR TITLE
Add missing return to runConnection

### DIFF
--- a/src/edgeChromiumDebugAdapter.ts
+++ b/src/edgeChromiumDebugAdapter.ts
@@ -68,7 +68,7 @@ export class EdgeChromiumDebugAdapter extends ChromeDebugAdapter {
 
     protected runConnection(): Promise<void>[] {
         if (!this._isDebuggerUsingWebView) {
-            super.runConnection();
+            return super.runConnection();
         } else {
             // For WebView we must no call super.runConnection() since that will cause the execution to resume before we are ready.
             // Instead we strip out the call to _chromeConnection.run() and call runIfWaitingForDebugger() once attach is complete.


### PR DESCRIPTION
This PR adds in a missing return statement to the runConnection() function.

Unfortunately the new edgeChromiumDebugAdapter was throwing an error when not using WebView2 debugging. This was due to the runConnection override returning undefined as it was calling the super class but forgetting to return the result.

* Adds missing return statement