### PR TITLE
fix: resume webviews created after attach

### DIFF
--- a/src/edgeChromiumDebugAdapter.ts
+++ b/src/edgeChromiumDebugAdapter.ts
@@ -158,7 +158,7 @@ export class EdgeChromiumDebugAdapter extends ChromeDebugAdapter {
         const pipeName = `VSCode_${crypto.randomBytes(12).toString('base64')}`;
         const serverName = `\\\\.\\pipe\\WebView2\\Debugger\\${exeName}\\${pipeName}`;
         const targetUrl = this.getWebViewLaunchUrl(args);
-        const isAttached = false;
+        let isAttached = false;
 
         // Clean up any previous pipe
         await new Promise((resolve) => {


### PR DESCRIPTION
WebViews are always paused on creation and need to be resumed, previously we only resumed WebViews before we attached to the first one over the pipe with a matching URL filter.