### PR TITLE
fix: README.md Edge (Chromium) example should use 'msedge' debugger type

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If the stable release of Microsoft Edge (Chromium) is on your machine, this debu
 ```json
 {
     "name": "Launch localhost in Microsoft Edge (Chromium) Canary",
-    "type": "edge",
+    "type": "msedge",
     "request": "launch",
     "version": "canary",
     "url": "http://localhost/mypage.html",


### PR DESCRIPTION
This change correct the README.me example configuration for Microsoft Edge (Chromium) to reflect the current support launch configuration.