### PR TITLE
Fix 'useWebView' not recognized as valid option

### DIFF
--- a/package.json
+++ b/package.json
@@ -711,6 +711,19 @@
                 "default": [
                   "page"
                 ]
+              },
+              "useWebView": {
+                "type": [
+                  "boolean",
+                  "string"
+                ],
+                "enum": [
+                  "advanced",
+                  true,
+                  false
+                ],
+                "description": "%edge.useWebView.description%",
+                "default": false
               }
             }
           },
@@ -826,6 +839,19 @@
                 "default": [
                   "page"
                 ]
+              },
+              "useWebView": {
+                "type": [
+                  "boolean",
+                  "string"
+                ],
+                "enum": [
+                  "advanced",
+                  true,
+                  false
+                ],
+                "description": "%edge.useWebView.description%",
+                "default": false
               }
             }
           }


### PR DESCRIPTION
The `useWebView` property was only declared for the `msedge` debugger type so we got a squiggly  warning in launch.json when using the `useWebView` property.

The fix is to add the `useWebView` option to the `edge` debugger type under both `launch` and `attach`.

Proof of fix from a local vsix package:
![fix-contrib](https://user-images.githubusercontent.com/309310/83202264-14d61a80-a0fc-11ea-9fe0-4555a054a93d.PNG)
